### PR TITLE
Stress changes

### DIFF
--- a/02-reset.sh
+++ b/02-reset.sh
@@ -1,0 +1,3 @@
+juju-deployer -D
+juju deploy juju-gui --to 0
+juju expose juju-gui

--- a/README.md
+++ b/README.md
@@ -47,7 +47,9 @@ Follow the steps:
 
 ### Connect external Zabbix server
 
-* You must open the following port 80 (interface), 10050 et 10051 (zabbix)
+* You must open the following ports:
+    * 80 (HTTP)
+    * 10050-10051 (Zabbix)
 
 * Create a security group if on AWS or OpenStack to ensure you can connect to and be sure you can access that machine/vm.
 
@@ -66,22 +68,25 @@ Once started and if you create a Zabbix machine run:
  
 `integrate-with-ext-zabbix <IP of the zabbix machine>`
 
-
-### Bulk user creation
-Run:  `BulkUsersCreation.sh` 
-
-
 ### Wanna test autoscaling?
 
-Enjoy your nodes automagically enrolled in Zabbix.
+This project includes the ability to generate simulated load against the system - the equivalent of
+40,000 subscribers making two calls an hour.
 
-    juju ssh clearwater-bono/0
-    sudo apt-get install -y -qq stress
-    stress --cpu 1 --io 2 --vm 2 --vm-bytes 512M --timeout 600
+To do this:
 
+* provision the 40,000 subscribers by running ./StressTestUserCreation.sh
+* create a relation between clearwater-bono and clearwater-sipp
 
+After about 8 minutes, CPU load average on Sprout will rise high enough for Zabbix to trigger a
+scale-up - you should be able to see this both on the graphs in Zabbix, and as a second node in the
+Juju GUI.
 
 ## Clean enviroment  
-When you are done, you can clean enviroment and destroy all services (do not terminate machines). 
+When you are done, you can clean the enviroment by running:
 
-    juju-deployer -D 
+    ./02-reset.sh
+
+This removes all the Clearwater services, but keeps the Juju GUI in place. (It also doesn't destroy
+the external Zabbix, so you only need to run `integrate-with-ext-zabbix <IP of the zabbix machine>`
+on future runs).

--- a/StressTestUserCreation.sh
+++ b/StressTestUserCreation.sh
@@ -2,20 +2,16 @@
 
 ## Try ping homer and homestead from ellis before adding user to check dns resolution
 
-juju ssh clearwater-homestead/0 '. /etc/clearwater/config; for DN in {2010000000..2010099999}; do echo sip:$DN@$home_domain,$DN@$home_domain,$home_domain,7kkzTyGW ; done > users.csv'
+juju ssh clearwater-homestead/0 '. /etc/clearwater/config; for DN in {2010000000..2010039999}; do echo sip:$DN@$home_domain,$DN@$home_domain,$home_domain,7kkzTyGW ; done > users.csv'
 
 juju ssh clearwater-homestead/0 "/usr/share/clearwater/homestead/src/metaswitch/crest/tools/bulk_autocomplete.py users.csv"
 juju ssh clearwater-homestead/0 "/usr/share/clearwater/homestead/src/metaswitch/crest/tools/bulk_create.py users.auto.csv"
 
-juju ssh clearwater-homestead/0 "./users.auto.create_homestead.sh"
+# Pipe the output to /dev/null to avoid spam
+juju ssh clearwater-homestead/0 "./users.auto.create_homestead.sh > /dev/null"
 
-TMP=`mktemp -d`
-juju scp clearwater-homestead/0:~/*xdm* $TMP/
-juju scp $TMP/*xdm* clearwater-homer/0:~/ 
-juju ssh clearwater-homer/0 "./users.auto.create_xdm.sh"
+# No need to provision users in Homer - these aren't used in stress
 
 DOMAIN=`juju ssh  clearwater-homestead/0 '. /etc/clearwater/config; echo $home_domain'`
-echo 'users range from 0000@'$DOMAIN
-echo 'to  0099@'$DOMAIN
-echo ' with password 7kkzTyGW created'
-echo "See clearwater doc to configure your clients"
+echo "Users from 2010000000@$DOMAIN to 2010039999@$DOMAIN have been created (password 7kkzTyGW)"
+echo "Use clearwater-sipp to run stress with these clients"

--- a/bundle-config.yaml
+++ b/bundle-config.yaml
@@ -60,6 +60,15 @@ nfv-demo:
         number_count: 1000
         # Ellis allows self-sign-up - anyone who has this signup key can create a user account and multiple lines, so it should be kept secure.
         signup_key: "abracadabra"
+    "clearwater-sipp":
+      options:
+        # Deployment-wide options
+        # These options should be set to the same value for all Clearwater charms
+        zone: "ims.clearwater.local"
+        repo: "http://repo.cw-ngv.com/juju-clearwater-1"
+
+        # SIPp-specific options
+        user_count: 40000
     dns:
       options:
         # The dns 'domain' option should match the Clearwater 'zone' option

--- a/bundle-nfv-demo.yaml
+++ b/bundle-nfv-demo.yaml
@@ -65,6 +65,16 @@ nfv-demo:
       annotations:
         "gui-x": "400"
         "gui-y": "0"
+    "clearwater-sipp":
+      charm: "local:precise/clearwater-sipp"
+      charm_url: "local:precise/clearwater-sipp"
+      num_units: 1
+      constraints: "arch=amd64"
+      options:
+        zone: "clearwater.local"
+      annotations:
+        "gui-x": "400"
+        "gui-y": "1200"
     dns:
       charm: "local:trusty/dns"
       charm_url: "local:trusty/dns"
@@ -118,6 +128,8 @@ nfv-demo:
     - - "clearwater-homer:programmable-multiple"
       - "dns:programmable-multiple"
     - - "clearwater-ellis:programmable-multiple"
+      - "dns:programmable-multiple"
+    - - "clearwater-sipp:programmable-multiple"
       - "dns:programmable-multiple"
     - - "clearwater-bono:cscf"
       - "clearwater-sprout:pcscf"

--- a/integrate-with-ext-zabbix
+++ b/integrate-with-ext-zabbix
@@ -53,7 +53,8 @@ $SSH "sudo chmod 644  /usr/lib/zabbix/externalscripts/.jujuapi.yaml"
 juju deploy  cs:~samuel-cozannet/precise/zabbix-agent || echo "already deployed keep going"
 juju set zabbix-agent server-host=$VM_IP
 
-juju add-relation clearwater-ellis zabbix-agent || echo "already related to ellis keep going"
+juju add-relation clearwater-ellis zabbix-agent || echo "Already related to Ellis, keep going"
+juju add-relation clearwater-sprout zabbix-agent || echo "Already related to Sprout, keep going"
 
-echo "You can now connect Got to th gui and connect clearwater services to zabbix-agent"
+echo "Sprout and Ellis are now connected to Zabbix. You can connect other services by creating a relation with zabbix-agent, either through the GUI or the command line."
 


### PR DESCRIPTION
This fixes #19 by adding the ability to do a SIP scalability test. It:
- integrates the clearwater-sipp charm
- changes the stress provisioning script to be faster
- documents how to trigger SIP stress and what effects to watch for
- adds a 'reset' script - I've found this helpful when I want to repeatedly test autoscaling, setting the deployment back to a clean state each time
